### PR TITLE
Spatial system

### DIFF
--- a/bin/resource/camera_test/camera.js
+++ b/bin/resource/camera_test/camera.js
@@ -1,0 +1,19 @@
+class Camera extends engine.Entity {
+	constructor() {
+		super(`Camera`);
+	}
+	
+	wasInitialized = () => {
+		engine.log(`Camera (${this.id}) wasInitialized`);
+		this.set_update_frequency(2);
+		this.add_transform_component();
+	}
+	
+	update = (frameDt, updateDt) => {
+		engine.log(`Camera (${this.id}) update (${frameDt.toFixed(2)}, ${updateDt.toFixed(2)})`);
+	}
+};
+
+export {
+	Camera
+};

--- a/bin/resource/camera_test/camera_test.js
+++ b/bin/resource/camera_test/camera_test.js
@@ -1,6 +1,5 @@
-const {
-	ObjFile
-} = require('obj');
+const { ObjFile } = require('obj');
+const { Camera } = require('camera');
 
 function format_size(sz) {
 	let mult = 1.0;
@@ -42,6 +41,8 @@ class CameraTestState extends engine.State {
 		
 		info.node.material_instance = material.instantiate();
 		info.node.material_instance.uniforms.vec3f("color", new vec3f(0.75, 0.1, 0.2));
+		
+		const camera = new Camera();
 	}
 	render = () => {
 		ImGui.Text(`Memory: ${format_size(this.used_memory)} / ${format_size(this.max_memory)}`);

--- a/bin/resource/entity_test/entity_test.js
+++ b/bin/resource/entity_test/entity_test.js
@@ -7,7 +7,7 @@ class TestEntity extends engine.Entity {
 	
 	wasInitialized = () => {
 		engine.log(`TestEntity(${this.id}) wasInitialized`);
-		this.set_update_frequency(200);
+		this.set_update_frequency(2);
 		this.subscribe("test_event");
 	}
 	

--- a/engine/r2/engine.h
+++ b/engine/r2/engine.h
@@ -51,19 +51,12 @@ namespace r2 {
 			script_man* scripts() const;
 			log_man* logs() const;
 			r2::window* window();
-
 			engine_state_data* get_engine_state_data(u16 factoryIdx);
 			scene* current_scene();
-
-			// functions for scripts
 			bool open_window(i32 w, i32 h, const mstring& title, bool can_resize = false, bool fullscreen = false);
-
-			// inherited functions
 			virtual void handle(event* evt);
-		  
-			// debug
-			void log(const mstring& pre,mstring msg,...);
-
+			void log(const mstring& pre, mstring msg,...);
+			void destroy_all_entities();
 
 			// loop functions
 			void initialize_new_entities();

--- a/engine/r2/managers/memman.cpp
+++ b/engine/r2/managers/memman.cpp
@@ -59,8 +59,8 @@ namespace r2 {
 
 	void* memory_allocator::allocate(size_t size) {
 		if (size > m_size - m_used) {
-			if (m_id == 1) printf("Failed to allocate %s bytes from allocator %d, which only has %s bytes available\n", format_size(size), m_id, format_size(m_size - m_used));
-			else r2Error("Failed to allocate %s bytes from allocator %d, which only has %s bytes available\n", format_size(size), m_id, format_size(m_size - m_used));
+			if (m_id == 1) printf("Failed to allocate %s bytes from allocator %d, which has %s bytes available\n", format_size(size), m_id, format_size(m_size - m_used));
+			else r2Error("Failed to allocate %s bytes from allocator %d, which has %s bytes available\n", format_size(size), m_id, format_size(m_size - m_used));
 
 			exit(-1);
 			return nullptr;
@@ -72,6 +72,38 @@ namespace r2 {
 		block->used = m_id;
 		m_used += size;
 		return ptrFromBlock(block);
+	}
+
+	void* memory_allocator::reallocate(void* ptr, size_t size) {
+		memory_block* block = blockFromPtr(ptr);
+		if (block->size == size) return ptr;
+		if (block->used == m_id) {
+			void* newPtr = reallocate_from_self(ptr, size);
+			if (!newPtr) {
+				if (m_id == 1) printf("Failed to reallocate %s bytes from allocator %d, which has %s bytes available\n", format_size(size), m_id, format_size(m_size - m_used));
+				else r2Error("Failed to allocate %s bytes from allocator %d, which has %s bytes available\n", format_size(size), m_id, format_size(m_size - m_used));
+
+				exit(-1);
+				return nullptr;
+			}
+
+			return newPtr;
+		}
+
+		// this allocator didn't allocate ptr... nice
+		if (block->used < m_id && m_last) {
+			void* newPtr = m_last->reallocate_called_from_other_allocator(block, ptr, size, m_id);
+			if (newPtr) return newPtr;
+		}
+
+		if (block->used > m_id && m_next) {
+			void* newPtr = m_next->reallocate_called_from_other_allocator(block, ptr, size, m_id);
+			if (newPtr) return newPtr;
+		}
+
+		r2Error("Memory leak detected. 0x%X was allocated by allocator %d, which was destroyed. Also, failed to reallocate data\n", ptr, block->used);
+		exit(-1);
+		return nullptr;
 	}
 
 	bool memory_allocator::deallocate(void* ptr) {
@@ -86,25 +118,6 @@ namespace r2 {
 		if (block->used > m_id && m_next && m_next->deallocate_called_from_other_allocator(block, ptr, m_id)) return true;
 
 		r2Error("Memory leak detected. 0x%X was allocated by allocator %d, which was destroyed.\n", ptr, block->used);
-		return false;
-	}
-
-	bool memory_allocator::deallocate_called_from_other_allocator(memory_block* block, void* ptr, allocator_id otherAllocatorId) {
-		if (block->used == m_id) {
-			deallocate_from_self(ptr);
-			return true;
-		}
-
-		if ((block->used > m_id && otherAllocatorId > m_id) || (block->used < m_id && otherAllocatorId < m_id)) {
-			// block was allocated by an allocator that was between this one and the one that called this function
-			// but was deleted. The memory used by ptr was released, back to the global allocator, but this is
-			// technically a memory leak
-			return false;
-		}
-
-		if (block->used < m_id && m_last && m_last->deallocate_called_from_other_allocator(block, ptr, m_id)) return true;
-		if (block->used > m_id && m_next && m_next->deallocate_called_from_other_allocator(block, ptr, m_id)) return true;
-
 		return false;
 	}
 
@@ -135,64 +148,6 @@ namespace r2 {
 		}
 	}
 
-	void memory_allocator::deallocate_from_self(void* ptr) {
-		memory_block* block = blockFromPtr(ptr);
-		assert(block->used == m_id);
-
-		block->used = false;
-		m_used -= block->size;
-
-		if (block->next && !block->next->used) {
-			// merge with next
-			block->size += block->next->size + sizeof(memory_block);
-			block->next = block->next->next;
-			checkSize(block);
-			m_used -= sizeof(memory_block);
-			m_blockCount--;
-		}
-
-		// can't merge backwards here because of the lack of memory_block::last,
-		// merge forward from the beginning instead every so often
-
-		m_mergeCounter--;
-		if (m_mergeCounter == 0) merge_adjacent_blocks();
-	}
-
-	memory_block* memory_allocator::find_available(size_t size) {
-		memory_block* b = m_baseBlock;
-		while(b) {
-			if (b->size > size + sizeof(memory_block) && !b->used) {
-				u8* bData = (u8*)ptrFromBlock(b);
-
-				if (checkSize(b)) {
-					memory_block* nb = (memory_block*)(bData + size);
-					nb->next = b->next;
-					nb->size = b->size - size - sizeof(memory_block);
-					nb->used = false;
-
-					b->next = nb;
-					b->size = size;
-					b->used = true;
-
-					checkSize(b);
-					checkSize(nb);
-
-					m_blockCount++;
-					m_used += sizeof(memory_block);
-					return b;
-				}
-			} else if(b->size == size && !b->used) {
-				return b;
-			}
-			b = b->next;
-		}
-
-		if (m_id == 1) printf("Failed to find memory for size %s\n", format_size(size));
-		else r2Error("Failed to find memory for size %s\n", format_size(size));
-
-		return nullptr;
-	}
-
 	void memory_allocator::debug(allocator_id level) {
 		merge_adjacent_blocks();
 
@@ -205,7 +160,7 @@ namespace r2 {
 		size_t other_unused = 0;
 		size_t other_used = 0;
 		memset(buckets, 0, sizeof(bucket) * 32);
-		
+
 		memory_block* b = m_baseBlock;
 		while(b) {
 			bool found = false;
@@ -248,6 +203,202 @@ namespace r2 {
 
 	allocator_id memory_allocator::id() const {
 		return m_id;
+	}
+
+	void memory_allocator::deallocate_from_self(void* ptr) {
+		memory_block* block = blockFromPtr(ptr);
+		assert(block->used == m_id);
+
+		block->used = false;
+		m_used -= block->size;
+
+		if (block->next && !block->next->used) {
+			// merge with next
+			block->size += block->next->size + sizeof(memory_block);
+			block->next = block->next->next;
+			checkSize(block);
+			m_used -= sizeof(memory_block);
+			m_blockCount--;
+		}
+
+		// can't merge backwards here because of the lack of memory_block::last,
+		// merge forward from the beginning instead every so often
+
+		m_mergeCounter--;
+		if (m_mergeCounter == 0) merge_adjacent_blocks();
+	}
+
+	bool memory_allocator::deallocate_called_from_other_allocator(memory_block* block, void* ptr, allocator_id otherAllocatorId) {
+		if (block->used == m_id) {
+			deallocate_from_self(ptr);
+			return true;
+		}
+
+		if ((block->used > m_id && otherAllocatorId > m_id) || (block->used < m_id && otherAllocatorId < m_id)) {
+			// block was allocated by an allocator that was between this one and the one that called this function
+			// but was deleted. The memory used by ptr was released, back to the global allocator, but this is
+			// technically a memory leak
+			return false;
+		}
+
+		if (block->used < m_id && m_last && m_last->deallocate_called_from_other_allocator(block, ptr, m_id)) return true;
+		if (block->used > m_id && m_next && m_next->deallocate_called_from_other_allocator(block, ptr, m_id)) return true;
+
+		return false;
+	}
+
+	void* memory_allocator::reallocate_from_self(void* ptr, size_t size) {
+		memory_block* block = blockFromPtr(ptr);
+		assert(block->used == m_id);
+
+		// should be what happens
+		if (size > block->size) {
+			size_t sizeDiff = size - block->size;
+
+			// first, see if the next block can be merged into this one to accomodate the new size
+			if (block->next && !block->next->used && block->next->size > sizeDiff) {
+				// yup. increase the size of this block, and construct a new block after it to refer
+				// to the remainder of the next block
+				size_t oldNextSize = block->next->size;
+				memory_block* blockAfterNext = block->next->next;
+
+				block->size = size;
+
+				memory_block* nextBlock = (memory_block*)(((u8*)ptr) + size);
+				nextBlock->next = blockAfterNext;
+				nextBlock->size = oldNextSize - sizeDiff;
+				nextBlock->used = false;
+
+				block->next = nextBlock;
+
+				return ptr;
+			} else {
+				// nope. allocate a new one, copy this one to it, and deallocate this one
+				void* newPtr = allocate(size);
+				memcpy(newPtr, ptr, block->size);
+
+				block->used = false;
+				m_used -= block->size;
+
+				if (block->next && !block->next->used) {
+					// merge with next
+					block->size += block->next->size + sizeof(memory_block);
+					block->next = block->next->next;
+					checkSize(block);
+					m_used -= sizeof(memory_block);
+					m_blockCount--;
+				}
+
+				// can't merge backwards here because of the lack of memory_block::last,
+				// merge forward from the beginning instead every so often
+
+				m_mergeCounter--;
+				if (m_mergeCounter == 0) merge_adjacent_blocks();
+
+				return newPtr;
+			}
+		} else {
+			size_t sizeDiff = block->size - size;
+			
+			// first, see if the next block can be expanded backwards
+			if (block->next && !block->next->used) {
+				size_t oldNextSize = block->next->size;
+				memory_block* blockAfterNext = block->next->next;
+
+				block->size = size;
+
+				memory_block* nextBlock = (memory_block*)(((u8*)ptr) + size);
+				nextBlock->next = blockAfterNext;
+				nextBlock->size = oldNextSize + sizeDiff;
+				nextBlock->used = false;
+
+				block->next = nextBlock;
+
+				return ptr;
+			} else if (sizeDiff > sizeof(memory_block)) {
+				// nope, but a new free block can be created in the gap left by shrinking this block
+
+				memory_block* oldNextBlock = block->next;
+
+				block->size = size;
+
+				memory_block* nextBlock = (memory_block*)(((u8*)ptr) + size);
+				nextBlock->next = oldNextBlock;
+				nextBlock->size = sizeDiff - sizeof(memory_block);
+				nextBlock->used = false;
+
+				block->next = nextBlock;
+
+				m_blockCount++;
+
+				return ptr;
+			} else {
+				// this block can't be shrunk, but that's fine. It can at least hold the data that it needs to
+				return ptr;
+			}
+		}
+
+		return nullptr;
+	}
+
+	void* memory_allocator::reallocate_called_from_other_allocator(memory_block* block, void* ptr, size_t size, allocator_id otherAllocatorId) {
+		if (block->used == m_id) {
+			return reallocate_from_self(ptr, size);
+		}
+
+		if ((block->used > m_id && otherAllocatorId > m_id) || (block->used < m_id && otherAllocatorId < m_id)) {
+			// block was allocated by an allocator that was between this one and the one that called this function
+			// but was deleted. The memory used by ptr was released, back to the global allocator, but this is
+			// technically a memory leak
+			return nullptr;
+		}
+
+		if (block->used < m_id && m_last) {
+			void* newPtr = m_last->reallocate_called_from_other_allocator(block, ptr, size, m_id);
+			if (newPtr) return newPtr;
+		}
+
+		if (block->used > m_id && m_next) {
+			void* newPtr = m_next->reallocate_called_from_other_allocator(block, ptr, size, m_id);
+			if (newPtr) return newPtr;
+		}
+
+		return nullptr;
+	}
+
+	memory_block* memory_allocator::find_available(size_t size) {
+		memory_block* b = m_baseBlock;
+		while(b) {
+			if (b->size > size + sizeof(memory_block) && !b->used) {
+				u8* bData = (u8*)ptrFromBlock(b);
+
+				if (checkSize(b)) {
+					memory_block* nb = (memory_block*)(bData + size);
+					nb->next = b->next;
+					nb->size = b->size - size - sizeof(memory_block);
+					nb->used = false;
+
+					b->next = nb;
+					b->size = size;
+					b->used = true;
+
+					checkSize(b);
+					checkSize(nb);
+
+					m_blockCount++;
+					m_used += sizeof(memory_block);
+					return b;
+				}
+			} else if(b->size == size && !b->used) {
+				return b;
+			}
+			b = b->next;
+		}
+
+		if (m_id == 1) printf("Failed to find memory for size %s\n", format_size(size));
+		else r2Error("Failed to find memory for size %s\n", format_size(size));
+
+		return nullptr;
 	}
 
 
@@ -373,6 +524,10 @@ namespace r2 {
 		return memory_man::get()->m_allocatorStack->allocator->allocate(size);
 	}
 
+	void* memory_man::reallocate(void* ptr, size_t size) {
+		return memory_man::get()->m_allocatorStack->allocator->reallocate(ptr, size);
+	}
+
 	void memory_man::deallocate(void* ptr) {
 		// will traverse the allocator list in both directions until the allocator that allocated this data is found
 		// starts at current allocator, since that's probably the most common case
@@ -403,6 +558,13 @@ namespace r2 {
 		//printf("r2alloc(%d:%d): 0x%X\n", sz, align(sz), (u64)ret);
 		//return ret;
 		return memory_man::allocate(align(sz));
+	}
+
+	void* r2realloc(void* ptr, size_t sz) {
+		//void* ret = memory_man::get()->allocate(align(sz));
+		//printf("r2alloc(%d:%d): 0x%X\n", sz, align(sz), (u64)ret);
+		//return ret;
+		return memory_man::reallocate(ptr, align(sz));
 	}
 
 	void r2free(void* ptr) {

--- a/engine/r2/managers/memman.h
+++ b/engine/r2/managers/memman.h
@@ -28,6 +28,7 @@ namespace r2 {
 			~memory_allocator();
 
 			void* allocate(size_t size);
+			void* reallocate(void* ptr, size_t size);
 			bool deallocate(void* ptr);
 			void deallocate_all();
 
@@ -44,6 +45,8 @@ namespace r2 {
 			memory_allocator();
 			void deallocate_from_self(void* ptr);
 			bool deallocate_called_from_other_allocator(memory_block* block, void* ptr, allocator_id otherAllocatorId);
+			void* reallocate_from_self(void* ptr, size_t size);
+			void* reallocate_called_from_other_allocator(memory_block* block, void* ptr, size_t size, allocator_id otherAllocatorId);
 
 			memory_block* find_available(size_t size);
 
@@ -71,6 +74,7 @@ namespace r2 {
 			static memory_allocator* global();
 
 			static void* allocate(size_t size);
+			static void* reallocate(void* ptr, size_t size);
 			static void deallocate(void* ptr);
 
 			static void debug();
@@ -97,6 +101,7 @@ namespace r2 {
 	};
 
 	void* r2alloc(size_t sz);
+	void* r2realloc(void* ptr, size_t sz);
 	void r2free(void* ptr);
 
 	template <typename T>

--- a/engine/r2/managers/stateman.cpp
+++ b/engine/r2/managers/stateman.cpp
@@ -84,6 +84,7 @@ namespace r2 {
 		m_mgr->initialize_state_engine_data(this);
 
 		initialize_periodic_update();
+		initialize_event_receiver();
 		m_scene = r2engine::get()->scenes()->create((*m_name) + "_scene");
 
 		LocalObjectHandle self = convert<state*>::to_v8(isolate, this);
@@ -175,6 +176,8 @@ namespace r2 {
 			m_scene = nullptr;
 		}
 
+		r2engine::get()->destroy_all_entities();
+
 		if (m_engineData) {
 			for(auto data : *m_engineData) {
 				delete data;
@@ -183,6 +186,7 @@ namespace r2 {
 			m_engineData = nullptr;
 		}
 		destroy_periodic_update();
+		destroy_event_receiver();
 		if (m_name) { delete m_name; m_name = nullptr; }
 		deactivate_allocator(true);
 	}

--- a/engine/r2/systems/entity.h
+++ b/engine/r2/systems/entity.h
@@ -5,6 +5,7 @@
 #include <r2/bindings/v8helpers.h>
 #include <r2/utilities/periodic_update.h>
 #include <r2/utilities/dynamic_array.hpp>
+#include <r2/bindings/math_converters.h>
 
 namespace r2 {
 	typedef u32 entityId;
@@ -184,6 +185,7 @@ namespace r2 {
 			virtual void unbind(scene_entity* entity) = 0;
 
 			virtual void initialize() { }
+			virtual void deinitialize() { }
 			virtual void tick(f32 dt) { }
 			virtual void handle(event* evt) { }
 
@@ -193,6 +195,7 @@ namespace r2 {
 			friend class r2engine;
 			engine_state_data_ref<entity_system_state> m_state;
 			void _initialize();
+			void _deinitialize();
 			void _entity_added(scene_entity* entity);
 			void _entity_removed(scene_entity* entity);
 			void initialize_entities();

--- a/engine/r2/systems/transform_sys.cpp
+++ b/engine/r2/systems/transform_sys.cpp
@@ -1,0 +1,56 @@
+#include <r2/engine.h>
+#include <r2/systems/transform_sys.h>
+
+namespace r2 {
+	transform_component::transform_component() {
+	}
+
+	transform_component::~transform_component() {
+	}
+
+
+	transform_sys::transform_sys() {
+	}
+
+	transform_sys::~transform_sys() {
+	}
+
+	void transform_sys::initialize_entity(scene_entity* entity) {
+		entity->bind(this, "add_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
+			system->addComponentTo(entity);
+		});
+	}
+	void transform_sys::deinitialize_entity(scene_entity* entity) {
+		state().enable();
+		if (!state()->contains_entity(entity->id())) entity->unbind("add_transform_component");
+	}
+
+	scene_entity_component* transform_sys::create_component(entityId id) {
+		state().enable();
+		auto out = state()->create<transform_component>(id);
+		state().disable();
+		return out;
+	}
+
+	void transform_sys::bind(scene_entity_component* component, scene_entity* entity) {
+		using c = transform_component;
+		entity->unbind("add_transform_component");
+		entity->bind(this, "remove_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
+			system->removeComponentFrom(entity);
+		});
+	}
+	void transform_sys::unbind(scene_entity* entity) {
+		entity->bind(this, "add_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
+			system->addComponentTo(entity);
+		});
+	}
+
+	void transform_sys::initialize() {
+	}
+
+	void transform_sys::tick(f32 dt) {
+	}
+
+	void transform_sys::handle(event* evt) {
+	}
+};

--- a/engine/r2/systems/transform_sys.cpp
+++ b/engine/r2/systems/transform_sys.cpp
@@ -2,7 +2,7 @@
 #include <r2/systems/transform_sys.h>
 
 namespace r2 {
-	transform_component::transform_component() {
+	transform_component::transform_component() : transform(mat4f(1.0f)) {
 	}
 
 	transform_component::~transform_component() {
@@ -35,11 +35,13 @@ namespace r2 {
 	void transform_sys::bind(scene_entity_component* component, scene_entity* entity) {
 		using c = transform_component;
 		entity->unbind("add_transform_component");
+		entity->bind(component, "transform", &c::transform);
 		entity->bind(this, "remove_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
 			system->removeComponentFrom(entity);
 		});
 	}
 	void transform_sys::unbind(scene_entity* entity) {
+		entity->unbind("transform");
 		entity->bind(this, "add_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
 			system->addComponentTo(entity);
 		});

--- a/engine/r2/systems/transform_sys.h
+++ b/engine/r2/systems/transform_sys.h
@@ -6,6 +6,8 @@ namespace r2 {
 		public:
 			transform_component();
 			~transform_component();
+
+			mat4f transform;
 	};
 
 	class transform_sys : public entity_system {

--- a/engine/r2/systems/transform_sys.h
+++ b/engine/r2/systems/transform_sys.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <r2/systems/entity.h>
+
+namespace r2 {
+	class transform_component : public scene_entity_component {
+		public:
+			transform_component();
+			~transform_component();
+	};
+
+	class transform_sys : public entity_system {
+		public:
+			transform_sys();
+			~transform_sys();
+
+			virtual const size_t component_size() const { return sizeof(transform_component); }
+			virtual const size_t max_component_count() const { return 3; }
+
+			virtual void initialize();
+			virtual void initialize_entity(scene_entity* entity);
+			virtual void deinitialize_entity(scene_entity* entity);
+			virtual scene_entity_component* create_component(entityId id);
+			virtual void bind(scene_entity_component* component, scene_entity* entity);
+			virtual void unbind(scene_entity* entity);
+			virtual void tick(f32 dt);
+			virtual void handle(event* evt);
+	};
+};
+

--- a/engine/r2/utilities/dynamic_array.hpp
+++ b/engine/r2/utilities/dynamic_array.hpp
@@ -1,0 +1,264 @@
+#pragma once
+#include <r2/managers/memman.h>
+
+namespace r2 {
+	class untyped_dynamic_pod_array {
+		public:
+			untyped_dynamic_pod_array(size_t elementSize) : m_elementSize(elementSize), m_count(0), m_capacity(16), m_data(new u8[elementSize * 16]) {
+			}
+			~untyped_dynamic_pod_array() {
+				delete [] m_data;
+				m_data = nullptr;
+			}
+
+			void* push() {
+				if (m_count == m_capacity) {
+					m_data = (u8*)r2realloc(m_data, m_capacity * 2 * m_elementSize);
+					m_capacity *= 2;
+				}
+
+				u8* ptr = m_data + (m_count * m_elementSize);
+				m_count++;
+
+				return ptr;
+			}
+
+			template <typename T, typename ... construction_args>
+			T* push(construction_args ... args) {
+				assert(sizeof(T) == m_elementSize);
+
+				if (m_count == m_capacity) {
+					m_data = (u8*)r2realloc(m_data, m_capacity * 2 * m_elementSize);
+					m_capacity *= 2;
+				}
+
+				u8* ptr = m_data + (m_count * m_elementSize);
+				m_count++;
+
+				return new (ptr) T(args...);
+			}
+
+			void remove(size_t index) {
+				m_count--;
+				if (index == m_count) {
+					if (m_count < m_capacity / 2) {
+						m_capacity /= 2;
+						m_data = (u8*)r2realloc(m_data, m_capacity * m_elementSize);
+					}
+					return;
+				}
+
+				u8* src = m_data + ((index + 1) * m_elementSize);
+				u8* dst = m_data + (index * m_elementSize);
+				size_t sz = m_elementSize * (m_count - index);
+				memcpy(dst, src, sz);
+
+				if (m_count < m_capacity / 2) {
+					m_capacity /= 2;
+					m_data = (u8*)r2realloc(m_data, m_capacity * m_elementSize);
+				}
+			}
+
+			template <typename T>
+			void for_each(void (*callback)(T*, size_t, bool&)) {
+				assert(sizeof(T) == m_elementSize);
+				if (m_count == 0) return;
+				bool brk = false;
+				for (size_t i = 0;i < m_count && !brk;i++) callback((T*)(m_data + (i * m_elementSize)), i, brk);
+			}
+
+			template <typename T>
+			void for_each(void (*callback)(T*)) {
+				assert(sizeof(T) == m_elementSize);
+				if (m_count == 0) return;
+				for (size_t i = 0;i < m_count;i++) callback(((T*)(m_data + (i * m_elementSize))));
+			}
+
+			inline void* at(size_t index) {
+				assert(index < m_count);
+				return m_data + (index * m_elementSize);
+			}
+
+			inline void* operator[](size_t index) {
+				assert(index < m_count);
+				return m_data + (index * m_elementSize);
+			}
+
+			template <typename T>
+			inline T* at(size_t index) {
+				assert(sizeof(T) == m_elementSize);
+				assert(index < m_count);
+				return (T*)(m_data + (index * m_elementSize));
+			}
+
+			template <typename T>
+			inline T* operator[](size_t index) {
+				assert(sizeof(T) == m_elementSize);
+				assert(index < m_count);
+				return (T*)(m_data + (index * m_elementSize));
+			}
+
+			inline size_t size() { return m_count; }
+
+		protected:
+			u8* m_data;
+			size_t m_count;
+			size_t m_capacity;
+			size_t m_elementSize;
+	};
+
+	template <typename K>
+	class untyped_associative_pod_array {
+		public:
+			untyped_associative_pod_array(size_t elementSize) : m_values(elementSize) {
+			}
+			~untyped_associative_pod_array() {
+			}
+
+			void* set(const K& key) {
+				m_offsets[key] = m_values.size();
+				return m_values.push();
+			}
+
+			template <typename T, typename ... construction_args>
+			T* set(const K& key, construction_args ... args) {
+				m_offsets[key] = m_values.size();
+				return m_values.push<T>(args...);
+			}
+
+			void* get(const K& key) {
+				return m_values.at(m_offsets[key]);
+			}
+
+			template <typename T>
+			T* get(const K& key) {
+				return m_values.at<T>(m_offsets[key]);
+			}
+
+			void remove(const K& key) {
+				size_t idx = m_offsets[key];
+				m_offsets.erase(key);
+
+				m_values.remove(idx);
+				for (auto offset : m_offsets) {
+					if (offset.second >= idx) m_offsets[offset.first]--;
+				}
+			}
+
+			template <typename T>
+			void for_each(void (*callback)(T*, size_t, bool&)) { m_values.for_each<T>(callback); }
+
+			template <typename T>
+			void for_each(void (*callback)(T*)) { m_values.for_each<T>(callback); }
+
+		protected:
+			untyped_dynamic_pod_array m_values;
+			munordered_map<K, size_t> m_offsets;
+	};
+	
+	template <typename T>
+	class dynamic_pod_array {
+		public:
+			dynamic_pod_array() : m_count(0), m_capacity(16), m_data(new T[16]) {
+			}
+			~dynamic_pod_array() {
+				delete [] m_data;
+				m_data = nullptr;
+			}
+
+			void push(const T& value) {
+				if (m_count == m_capacity) {
+					m_data = r2realloc(m_data, m_capacity * 2 * sizeof(T));
+					m_capacity *= 2;
+				}
+
+				memcpy(m_data + m_count, &value, sizeof(T));
+				m_count++;
+			}
+
+			template <typename ... construction_args>
+			void push(construction_args ... args) {
+				if (m_count == m_capacity) {
+					m_data = r2realloc(m_data, m_capacity * 2 * sizeof(T));
+					m_capacity *= 2;
+				}
+
+				new (m_data + m_count) T(args...);
+				m_count++;
+			}
+
+			void remove(size_t index) {
+				m_count--;
+
+				if (m_count < m_capacity / 2) {
+					m_data = r2realloc(m_data, (m_capacity / 2) * sizeof(T));
+					m_capacity /= 2;
+				}
+
+				if (index == m_count) return;
+
+				memcpy(m_data + index, m_data + (index + 1), sizeof(T) * (m_count - (index + 1)));
+			}
+
+			void for_each(void (*callback)(T*, size_t, bool&)) {
+				if (m_count == 0) return;
+				bool brk = false;
+				for (size_t i = 0;i < m_count && !brk;i++) callback(&m_data[i], i, brk);
+			}
+
+			void for_each(void (*callback)(T*)) {
+				if (m_count == 0) return;
+				for (size_t i = 0;i < m_count;i++) callback(&m_data[i]);
+			}
+
+			inline T* at(size_t index) { return &m_data[index]; }
+			inline T* operator[](size_t index) { return &m_data[index]; }
+			
+
+		protected:
+			T* m_data;
+			size_t m_count;
+			size_t m_capacity;
+	};
+
+	template <typename K, typename T>
+	class associative_pod_array {
+		public:
+			associative_pod_array() {
+			}
+			~associative_pod_array() {
+			}
+
+			void set(const K& key, const T& value) {
+				m_offsets[key] = m_values.size();
+				m_values.push(value);
+			}
+
+			template <typename ... construction_args>
+			void set(const K& key, construction_args ... args) {
+				m_offsets[key] = m_values.size();
+				m_values.push(args...);
+			}
+
+			T* get(const K& key) {
+				return m_values.at(m_offsets[key]);
+			}
+
+			void remove(const K& key) {
+				size_t idx = m_offsets[key];
+				m_offsets.erase(key);
+
+				m_values.remove(idx);
+				for (auto offset : m_offsets) {
+					if (offset.second >= idx) offset.second--;
+				}
+			}
+
+			void for_each(void (*callback)(T*, size_t, bool&)) { m_values.for_each(callback); }
+			void for_each(void (*callback)(T*)) { m_values.for_each(callback); }
+
+		protected:
+			dynamic_pod_array<T> m_values;
+			munordered_map<K, size_t> m_offsets;
+	};
+};

--- a/engine/r2/utilities/event.cpp
+++ b/engine/r2/utilities/event.cpp
@@ -91,31 +91,60 @@ namespace r2 {
 
     event_receiver::event_receiver(memory_allocator* memory) : m_memory(memory), m_isAtFrameStart(true) {
 		if (!m_memory) m_memory = memory_man::global();
+
+		m_frameStartEvents = nullptr;
+		m_nextFrameStartEvents = nullptr;
+		m_children = nullptr;
+		m_subscribesTo = nullptr;
+		m_parent = nullptr;
     }
 
     event_receiver::~event_receiver() {
+		if (m_frameStartEvents) destroy_event_receiver();
     }
 
+	void event_receiver::initialize_event_receiver() {
+		m_frameStartEvents = new mvector<event*>();
+		m_nextFrameStartEvents = new mvector<event*>();
+		m_children = new mlist<event_receiver*>();
+		m_subscribesTo = new mlist<mstring>();
+	}
+
+	void event_receiver::destroy_event_receiver() {
+		if (m_parent) m_parent->remove_child(this);
+
+		delete m_frameStartEvents;
+		delete m_nextFrameStartEvents;
+		delete m_children;
+		delete m_subscribesTo;
+		m_frameStartEvents = nullptr;
+		m_nextFrameStartEvents = nullptr;
+		m_children = nullptr;
+		m_subscribesTo = nullptr;
+	}
+
     void event_receiver::add_child(event_receiver *child) {
-        m_children.push_front(child);
+        m_children->push_front(child);
+		child->m_parent = this;
     }
 
     void event_receiver::remove_child(event_receiver* child) {
-        for(auto i = m_children.begin();i != m_children.end();i++) {
+        for(auto i = m_children->begin();i != m_children->end();i++) {
             if((*i) == child) {
-                m_children.erase(i);
+                m_children->erase(i);
+				child->m_parent = nullptr;
                 return;
             }
         }
     }
 	void event_receiver::subscribe(const mstring& eventName) {
-		m_subscribesTo.push_front(eventName);
+		m_subscribesTo->push_front(eventName);
 	}
 
 	void event_receiver::unsubscribe(const mstring& eventName) {
-		for(auto i = m_subscribesTo.begin();i != m_subscribesTo.end();i++) {
+		for(auto i = m_subscribesTo->begin();i != m_subscribesTo->end();i++) {
 			if((*i) == eventName) {
-				m_subscribesTo.erase(i);
+				m_subscribesTo->erase(i);
 				return;
 			}
 		}
@@ -124,12 +153,13 @@ namespace r2 {
 	void event_receiver::frame_started() {
 		m_isAtFrameStart = true;
 		memory_man::push_current(memory_man::global());
-		for (auto child : m_children) child->frame_started();
-		for (auto e : m_frameStartEvents) {
+		for (auto child : *m_children) child->frame_started();
+		for (auto e : *m_frameStartEvents) {
 			dispatch(e);
 			delete e;
 		}
-		m_frameStartEvents.clear();
+		delete m_frameStartEvents;
+		m_frameStartEvents = new mvector<event*>();
 		swap(m_frameStartEvents, m_nextFrameStartEvents);
 		memory_man::pop_current();
 		m_isAtFrameStart = false;
@@ -139,9 +169,9 @@ namespace r2 {
         if(e->data()) e->data()->set_position(0);
 
 		bool subscribesTo = true;
-		if (m_subscribesTo.size() > 0) {
+		if (m_subscribesTo->size() > 0) {
 			subscribesTo = false;
-			for(auto ename : m_subscribesTo) {
+			for(auto ename : *m_subscribesTo) {
 				if (ename == e->name()) {
 					subscribesTo = true;
 					break;
@@ -157,7 +187,7 @@ namespace r2 {
 		}
 
         if(!e->is_recursive()) return;
-        for(auto i = m_children.begin();i != m_children.end();i++) {
+        for(auto i = m_children->begin();i != m_children->end();i++) {
             (*i)->dispatch(e);
         }
     }
@@ -165,11 +195,11 @@ namespace r2 {
 	void event_receiver::dispatchAtFrameStart(event* e) {
 		memory_man::push_current(memory_man::global());
 		if (m_isAtFrameStart) {
-			m_nextFrameStartEvents.push_back(new event(*e));
+			m_nextFrameStartEvents->push_back(new event(*e));
 			return;
 		}
 
-		m_frameStartEvents.push_back(new event(*e));
+		m_frameStartEvents->push_back(new event(*e));
 		memory_man::pop_current();
 	}
 }

--- a/engine/r2/utilities/event.h
+++ b/engine/r2/utilities/event.h
@@ -56,6 +56,9 @@ namespace r2 {
             event_receiver(memory_allocator* memory = nullptr);
             virtual ~event_receiver();
 
+			void initialize_event_receiver();
+			void destroy_event_receiver();
+
             void add_child(event_receiver* child);
             void remove_child(event_receiver* child);
 
@@ -73,9 +76,10 @@ namespace r2 {
         private:
 			bool m_isAtFrameStart;
 			memory_allocator* m_memory;
-			mvector<event*> m_frameStartEvents;
-			mvector<event*> m_nextFrameStartEvents;
-            mlist<event_receiver*> m_children;
-			mlist<mstring> m_subscribesTo;
+			mvector<event*>* m_frameStartEvents;
+			mvector<event*>* m_nextFrameStartEvents;
+            mlist<event_receiver*>* m_children;
+			mlist<mstring>* m_subscribesTo;
+			event_receiver* m_parent;
     };
 }

--- a/tests/entity/main.cpp
+++ b/tests/entity/main.cpp
@@ -16,7 +16,6 @@ class test_system : public entity_system {
 		~test_system() { }
 
 		virtual const size_t component_size() const { return sizeof(test_component); }
-		virtual const size_t max_component_count() const { return 3; }
 
 		virtual void initialize_entity(scene_entity* entity) {
 			entity->bind("test_callback");
@@ -45,9 +44,11 @@ class test_system : public entity_system {
 
 		virtual void bind(scene_entity_component* component, scene_entity* entity) {
 			using c = test_component;
+
 			entity->bind(component, "x", &c::x);
 			entity->bind(component, "y", &c::y);
 			entity->bind(component, "z", &c::z);
+
 			entity->bind(this, "test_component_id", [](entity_system* system, scene_entity* entity, v8Args args) {
 				system->state().enable();
 				auto component = system->state()->entity(entity->id());


### PR DESCRIPTION
- Added `transform_sys`, `transform_component`
- Updated camera test
- Added `r2realloc` and associated `memory_man` methods
- Fixed issues with entities not getting destroyed at the correct times, being leaked, etc
- Added the following utilities for faster management of arrays/maps of POD structures:
    * `dynamic_pod_array`
    * `untyped_dynamic_pod_array`
    * `associative_pod_array`
    * `untyped_associative_pod_array`
- Made entity systems use above utilities to remove the need to specify a maximum number of components (but still have mapped, non-copy constructed, contiguous arrays of them)
- Made `event_receiver` constructor/destructor not automatically control memory allocations/deallocations. (to ensure that the dynamic allocations made by `std::` containers is allocated / deallocated in the correct memory scope, to prevent leaks when states are destroyed)
