### PR TITLE
Camera system

### DIFF
--- a/bin/builtin.js
+++ b/bin/builtin.js
@@ -679,13 +679,13 @@ var Transform2D = {
 };
 
 var View = {
-    lookAt: (eye, center, up) => { const out = new mat4f(); _glMatrix._mat4.lookAt(eye.__arr, center.__arr, up.__arr); return out; }
+    lookAt: (eye, center, up) => { const out = new mat4f(); _glMatrix._mat4.lookAt(out.__arr, eye.__arr, center.__arr, up.__arr); return out; }
 };
 
 var Projection = {
     frustum: (left, right, bottom, top, near, far) => { const out = new mat4f(); _glMatrix._mat4.frustum(out.__arr, left, right, bottom, top, near, far); return out; },
     ortho: (left, right, bottom, top, near, far) => { const out = new mat4f(); _glMatrix._mat4.ortho(out.__arr, left, right, bottom, top, near, far); return out; },
-    perspective: (fov, aspect, near, far) => { const out = mat4f(); _glMatrix._mat4.perspective(out.__arr, fov * DEG_TO_RAD, aspect, near, far); return out; },
+    perspective: (fov, aspect, near, far) => { const out = new mat4f(); _glMatrix._mat4.perspective(out.__arr, fov * DEG_TO_RAD, aspect, near, far); return out; },
     perspectiveFromFieldOfView: (fovUp, fovDown, fovLeft, fovRight, near, far) => {
         const out = mat4f();
         // this function actually does use degrees, for some reason.

--- a/bin/resource/camera_test/camera.js
+++ b/bin/resource/camera_test/camera.js
@@ -5,12 +5,24 @@ class Camera extends engine.Entity {
 	
 	wasInitialized = () => {
 		engine.log(`Camera (${this.id}) wasInitialized`);
-		this.set_update_frequency(2);
+		this.set_update_frequency(60);
 		this.add_transform_component();
+		this.add_camera_component();
+		this.activate();
+		this.time = 0.0;
+		
+		this.target = new vec3f(0, 0, 0);
+		this.position = new vec3f(0, 0, 0);
+		this.up = new vec3f(0, 1, 0);
 	}
 	
 	update = (frameDt, updateDt) => {
-		engine.log(`Camera (${this.id}) update (${frameDt.toFixed(2)}, ${updateDt.toFixed(2)})`);
+		this.time += updateDt;
+		this.position = vec3.rotateY(this.target.add(new vec3f(0, 8, -10)), this.target, this.time * 30.0);
+		
+		var windowSize = engine.window_size();
+		this.projection = Projection.perspective(60.0, windowSize.x / windowSize.y, 0.001, 100.0);
+		this.transform = View.lookAt(this.position, this.target, this.up);
 	}
 };
 

--- a/bin/resource/camera_test/camera_test.js
+++ b/bin/resource/camera_test/camera_test.js
@@ -30,9 +30,7 @@ class CameraTestState extends engine.State {
 		ifmt.addAttr(gfx.InstanceAttrType.mat4f);
 		mfmt.addAttr("color", gfx.UniformAttrType.vec3f);
 		
-		const transform = Transform3D.translation(new vec3f(0, 0, 0));
-		transform.mulEq(Transform3D.rotation(new vec3f(0, 0, 1), 90));
-		transform.mulEq(Transform3D.scale(new vec3f(1.25, 1.25, 1.25)));
+		const transform = Transform3D.scale(new vec3f(1.25, 1.25, 1.25));
 		
 		const info = o.makeNode(vfmt, ifmt, [{ transform }]);
 		

--- a/engine/r2/bindings/engine_bindings.cpp
+++ b/engine/r2/bindings/engine_bindings.cpp
@@ -165,6 +165,10 @@ namespace r2 {
 		args.GetReturnValue().Set(engine->open_window(v_width, v_height, v_title, v_can_resize, v_fullscreen));
 	}
 
+	vec2i window_size() {
+		return r2engine::get()->window()->get_size();
+	}
+
 	void register_state(state* s) {
 		r2engine::get()->states()->register_state(s);
 	}
@@ -226,6 +230,7 @@ namespace r2 {
 		m.set("dispatch", &dispatch);
 		m.set("logs", &logs);
 		m.set("open_window", &open_window);
+		m.set("window_size", &window_size);
 		m.set("register_state", &register_state);
 		m.set("activate_state", &activate_state);
 

--- a/engine/r2/engine.cpp
+++ b/engine/r2/engine.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 #include <r2/systems/transform_sys.h>
+#include <r2/systems/camera_sys.h>
 
 namespace r2 {
 	r2engine* r2engine::instance = nullptr;
@@ -79,6 +80,7 @@ namespace r2 {
 		if (instance) return;
 
 		r2engine::register_system(new transform_sys());
+		r2engine::register_system(new camera_sys());
 
 		logMgr = new log_man();
 		instance = new r2engine(argc, argv);
@@ -100,7 +102,7 @@ namespace r2 {
 			instance->m_globalStateData.push_back(data);
 		}
 
-		instance->scripts()->executeFile("./builtin.min.js");
+		instance->scripts()->executeFile("./builtin.js");
 	}
 
 

--- a/engine/r2/managers/sceneman.cpp
+++ b/engine/r2/managers/sceneman.cpp
@@ -3,6 +3,7 @@
 
 #include <r2/systems/camera_sys.h>
 #include <r2/systems/transform_sys.h>
+#include <r2/systems/cascade_functions.h>
 
 namespace r2 {
     // render node
@@ -231,7 +232,9 @@ namespace r2 {
 		if (camera && camera->camera) {
 			mat4f proj = camera->camera->projection;
 			mat4f view = mat4f(1.0f);
-			if (camera->transform) view = camera->transform->transform;
+			if (camera->transform) {
+				view = camera->transform->cascaded_property(&transform_component::transform, &cascade_mat4f);
+			}
 
 			m_sceneUniforms->uniform_mat4f("transform", view);
 			m_sceneUniforms->uniform_mat4f("projection", proj);

--- a/engine/r2/managers/sceneman.h
+++ b/engine/r2/managers/sceneman.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <r2/systems/entity.h>
 
 #include <r2/managers/memman.h>
 #include <r2/bindings/v8helpers.h>
@@ -101,6 +102,8 @@ namespace r2 {
 			void render();
 
 			void release_resources();
+
+			scene_entity* camera;
 
         protected:
             friend class scene_man;

--- a/engine/r2/systems/camera_sys.cpp
+++ b/engine/r2/systems/camera_sys.cpp
@@ -1,0 +1,104 @@
+#include <r2/engine.h>
+#include <r2/systems/camera_sys.h>
+
+namespace r2 {
+	camera_component::camera_component() : projection(mat4f(1.0f)), active(false) {
+	}
+
+	camera_component::~camera_component() {
+	}
+
+
+	camera_sys::camera_sys() {
+	}
+
+	camera_sys::~camera_sys() {
+	}
+
+	void camera_sys::initialize_entity(scene_entity* entity) {
+		entity->bind(this, "add_camera_component", [](entity_system* system, scene_entity* entity, v8Args args) {
+			system->addComponentTo(entity);
+		});
+	}
+	void camera_sys::deinitialize_entity(scene_entity* entity) {
+		auto s = state();
+		s.enable();
+		if (!s->contains_entity(entity->id())) entity->unbind("add_camera_component");
+		s.disable();
+	}
+
+	scene_entity_component* camera_sys::create_component(entityId id) {
+		auto s = state();
+		s.enable();
+		auto out = s->create<camera_component>(id);
+		s.disable();
+		return out;
+	}
+
+	void camera_sys::bind(scene_entity_component* component, scene_entity* entity) {
+		using c = camera_component;
+		entity->unbind("add_camera_component");
+		entity->bind(component, "projection", &c::projection);
+		entity->bind(component, "active", &c::active, true);
+		entity->bind(this, "activate", [](entity_system* sys, scene_entity* entity, v8Args args) {
+			scene* curScene = r2engine::get()->current_scene();
+			if (!curScene) {
+				r2Error("There is no active scene for which to set an active camera");
+				return;
+			}
+
+			auto state = sys->state();
+			state.enable();
+			camera_component* cam = (camera_component*)state->entity(entity->id());
+
+			// do nothing if the camera is already active
+			if (cam->active) {
+				state.disable();
+				return;
+			}
+
+			// set the active camera to inactive, if there is one
+			state->for_each<camera_component>([](camera_component* c, size_t idx, bool& should_break) {
+				// break if the active camera is found
+				should_break = c->active;
+
+				// deactivate
+				c->active = false;
+			});
+
+			// activate this one
+			cam->active = true;
+			curScene->camera = entity;
+
+			
+			state.disable();
+		});
+		entity->bind(this, "remove_camera_component", [](entity_system* system, scene_entity* entity, v8Args args) {
+			system->removeComponentFrom(entity);
+		});
+		entity->camera = component_ref<camera_component*>(this, component->id());
+	}
+	void camera_sys::unbind(scene_entity* entity) {
+		entity->unbind("camera");
+		entity->bind(this, "add_camera_component", [](entity_system* system, scene_entity* entity, v8Args args) {
+			system->addComponentTo(entity);
+		});
+		
+		scene* curScene = r2engine::get()->current_scene();
+		if (curScene && curScene->camera == entity) {
+			r2Warn("Camera component removed from active camera. The scene will now have no active camera");
+			curScene->camera = nullptr;
+		}
+
+		entity->camera.clear();
+	}
+
+	void camera_sys::initialize() {
+	}
+
+	void camera_sys::tick(f32 dt) {
+	}
+
+	void camera_sys::handle(event* evt) {
+	}
+};

--- a/engine/r2/systems/camera_sys.h
+++ b/engine/r2/systems/camera_sys.h
@@ -2,20 +2,21 @@
 #include <r2/systems/entity.h>
 
 namespace r2 {
-	class transform_component : public scene_entity_component {
+	class camera_component : public scene_entity_component {
 		public:
-			transform_component();
-			~transform_component();
+			camera_component();
+			~camera_component();
 
-			mat4f transform;
+			mat4f projection;
+			bool active;
 	};
 
-	class transform_sys : public entity_system {
+	class camera_sys : public entity_system {
 		public:
-			transform_sys();
-			~transform_sys();
+			camera_sys();
+			~camera_sys();
 
-			virtual const size_t component_size() const { return sizeof(transform_component); }
+			virtual const size_t component_size() const { return sizeof(camera_component); }
 
 			virtual void initialize();
 			virtual void initialize_entity(scene_entity* entity);

--- a/engine/r2/systems/cascade_functions.cpp
+++ b/engine/r2/systems/cascade_functions.cpp
@@ -1,0 +1,5 @@
+#include <r2/systems/cascade_functions.h>
+
+namespace r2 {
+	mat4f cascade_mat4f(const mat4f& parent, const mat4f& child) { return parent * child; }
+};

--- a/engine/r2/systems/cascade_functions.h
+++ b/engine/r2/systems/cascade_functions.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <r2/config.h>
+
+namespace r2 {
+	mat4f cascade_mat4f(const mat4f& parent, const mat4f& child);
+};

--- a/engine/r2/systems/entity.cpp
+++ b/engine/r2/systems/entity.cpp
@@ -5,6 +5,23 @@ using namespace v8;
 using namespace v8pp;
 
 namespace r2 {
+	bool __component_exists(entity_system* sys, componentId id) {
+		auto state = sys->state();
+		state.enable();
+		bool valid = state->contains_component(id);
+		state.disable();
+		return valid;
+	}
+
+	scene_entity_component* __get_component(entity_system* sys, componentId id) {
+		auto state = sys->state();
+		state.enable();
+		auto comp = state->component(id);
+		state.disable();
+		return comp;
+	}
+
+
 	entityId scene_entity::nextEntityId = 1;
 	scene_entity::scene_entity(v8Args args)
 		: m_id(scene_entity::nextEntityId++), m_name(nullptr), m_scriptFuncs(nullptr), m_destroyed(false), m_parent(nullptr), m_children(nullptr) {
@@ -279,6 +296,10 @@ namespace r2 {
 		return m_entityComponentIds->count(id) > 0;
 	}
 
+	bool entity_system_state::contains_component(componentId id) {
+		return m_components->has(id);
+	}
+
 	void entity_system_state::destroy(entityId forEntity) {
 		auto ecomp = m_entityComponentIds->find(forEntity);
 		if (ecomp == m_entityComponentIds->end()) {
@@ -365,9 +386,8 @@ namespace r2 {
 			m_state->destroy(entity->id());
 		}
 
-		m_state.disable();
-
 		deinitialize_entity(entity);
+		m_state.disable();
 	}
 
 	void entity_system::initialize_entities() {

--- a/engine/r2/systems/entity.cpp
+++ b/engine/r2/systems/entity.cpp
@@ -46,6 +46,9 @@ namespace r2 {
 
 		m_scriptFuncs = new munordered_map<mstring, PersistentFunctionHandle>();
 		m_children = new mlist<scene_entity*>();
+
+		initialize_periodic_update();
+		initialize_event_receiver();
 		r2engine::entity_created(this);
 	}
 
@@ -172,8 +175,6 @@ namespace r2 {
 	}
 
 	void scene_entity::initialize() {
-		initialize_periodic_update();
-		initialize_event_receiver();
 		start_periodic_updates();
 
 		if (m_scriptObj.IsEmpty()) return;
@@ -337,6 +338,7 @@ namespace r2 {
 		}
 		scene_entity_component* comp = create_component(entity->id());
 		comp->m_system = this;
+		comp->m_entity = entity;
 		bind(comp, entity);
 		m_state.disable();
 	}

--- a/engine/r2/systems/transform_sys.cpp
+++ b/engine/r2/systems/transform_sys.cpp
@@ -21,14 +21,17 @@ namespace r2 {
 		});
 	}
 	void transform_sys::deinitialize_entity(scene_entity* entity) {
-		state().enable();
-		if (!state()->contains_entity(entity->id())) entity->unbind("add_transform_component");
+		auto s = state();
+		s.enable();
+		if (!s->contains_entity(entity->id())) entity->unbind("add_transform_component");
+		s.disable();
 	}
 
 	scene_entity_component* transform_sys::create_component(entityId id) {
-		state().enable();
-		auto out = state()->create<transform_component>(id);
-		state().disable();
+		auto s = state();
+		s.enable();
+		auto out = s->create<transform_component>(id);
+		s.disable();
 		return out;
 	}
 
@@ -36,6 +39,7 @@ namespace r2 {
 		using c = transform_component;
 		entity->unbind("add_transform_component");
 		entity->bind(component, "transform", &c::transform);
+		entity->transform = component_ref<transform_component*>(this, component->id());
 		entity->bind(this, "remove_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
 			system->removeComponentFrom(entity);
 		});
@@ -45,6 +49,7 @@ namespace r2 {
 		entity->bind(this, "add_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
 			system->addComponentTo(entity);
 		});
+		entity->transform.clear();
 	}
 
 	void transform_sys::initialize() {

--- a/engine/r2/systems/transform_sys.cpp
+++ b/engine/r2/systems/transform_sys.cpp
@@ -1,5 +1,6 @@
 #include <r2/engine.h>
 #include <r2/systems/transform_sys.h>
+#include <r2/systems/cascade_functions.h>
 
 namespace r2 {
 	transform_component::transform_component() : transform(mat4f(1.0f)) {
@@ -38,7 +39,7 @@ namespace r2 {
 	void transform_sys::bind(scene_entity_component* component, scene_entity* entity) {
 		using c = transform_component;
 		entity->unbind("add_transform_component");
-		entity->bind(component, "transform", &c::transform);
+		entity->bind(component, "transform", &c::transform, false, true, &cascade_mat4f, "full_transform");
 		entity->transform = component_ref<transform_component*>(this, component->id());
 		entity->bind(this, "remove_transform_component", [](entity_system* system, scene_entity* entity, v8Args args) {
 			system->removeComponentFrom(entity);

--- a/engine/r2/utilities/dynamic_array.hpp
+++ b/engine/r2/utilities/dynamic_array.hpp
@@ -135,6 +135,10 @@ namespace r2 {
 				return m_values.at<T>(m_offsets[key]);
 			}
 
+			bool has(const K& key) {
+				return m_offsets.count(key) > 0;
+			}
+
 			void remove(const K& key) {
 				size_t idx = m_offsets[key];
 				m_offsets.erase(key);
@@ -242,6 +246,10 @@ namespace r2 {
 
 			T* get(const K& key) {
 				return m_values.at(m_offsets[key]);
+			}
+
+			bool has(const K& key) {
+				return m_offsets.count(key) > 0;
 			}
 
 			void remove(const K& key) {


### PR DESCRIPTION
- Added `camera_sys`, `camera_component`
- Added `component_ref` helper, for referencing components without needing to write out all of the logic to do so
- Added `engine.window_size()` call to global JS `engine` object
- Fixed glMatrix usage error in builtin.js
- Fixed missing `new` in builtin.js
- Updated camera test
- Made `scene_man` refer to active camera entity for view and projection matrices (this setup is probably not final, it was prepared without much forethought just to test cameras, transforms, cascading components)
- Added method to `scene_entity_component` for getting the final product of a cascading component property
- Added parameters to `scene_entity::bind` (for properties) to allow for binding a read-only get accessor for the final product of a cascading component property
- Made `transform_component::transform` a cascading property, accessible to scripted entities via `this.full_transform`

